### PR TITLE
Improve showing multiple exceptions with same status code

### DIFF
--- a/fastapi_responses/utils.py
+++ b/fastapi_responses/utils.py
@@ -70,3 +70,16 @@ def write_response(api_schema: dict, route: APIRoute, exc: HTTPException) -> Non
             api_schema["paths"][path][method]["responses"][status_code] = {
                 "description": exc.detail
             }
+        else:
+            count = get_status_code_count(
+                api_schema["paths"][path][method]["responses"], status_code, 1
+            )
+            api_schema["paths"][path][method]["responses"][f"{status_code}.{count}"] = {
+                "description": exc.detail
+            }
+
+
+def get_status_code_count(status_code_list, status_code, counter):
+    if (f"{status_code}.{counter}") not in status_code_list:
+        return counter
+    return get_status_code_count(status_code_list, status_code, counter + 1)

--- a/tests/test_multiple_exceptions.py
+++ b/tests/test_multiple_exceptions.py
@@ -67,6 +67,7 @@ openapi_schema = {
                             "I need a really long sentence so I can analyze..."
                         )
                     },
+                    "200.1": {"description": "Another function!"},
                     "201": {"description": "HAHA"},
                     "304": {"description": "Yet another function!"},
                 },


### PR DESCRIPTION
Hi, when there are multiple exceptions with same status code, only first one shown in the docs.

The code below was documenting only `404 | Item not found.` part.

``` python
from fastapi import FastAPI, HTTPException
from fastapi_responses import custom_openapi

app = FastAPI()

app.openapi = custom_openapi(app)

@app.get("/{item_id}")
def get_item(item_id: int, user_id: int):
    if item_id == 0:
        raise HTTPException(status_code=404, detail="Item not found.")
    if user_id == 0:
        raise HTTPException(status_code=404, detail="User not found.")
    return "Item exists!"

```

With this commit, above code will document both exceptions.
```
404 | Item not found.
404.1 | User not found.
```